### PR TITLE
添加了代码显示设置语言类型的功能

### DIFF
--- a/web/src/css/tailwind.css
+++ b/web/src/css/tailwind.css
@@ -17,6 +17,9 @@
     overflow-wrap: anywhere;
     word-break: normal;
   }
+  .strikethrough {
+  text-decoration: line-through;
+  }
 }
 
 @layer components {

--- a/web/src/labs/marked/parser/CodeBlock.tsx
+++ b/web/src/labs/marked/parser/CodeBlock.tsx
@@ -34,10 +34,10 @@ const renderer = (rawStr: string) => {
 
   return (
     <pre className="group block-code mt-2">
-      <div className="language-info absolute top-0 left-0 px-2 py-1 text-xs font-mono bg-indigo-600 text-white rounded-bl-lg rounded-tr-lg">
+      <div className="language-info absolute top-0 left-0 px-2 py-1 text-xs font-mono bg-orange-200 text-orange-800 rounded-bl-lg rounded-tr-lg">
         {language}
       </div>
-      <div className="w-full h-0.5 bg-indigo-600"></div> {/* 横线，用于分隔 */}
+      <div className="w-full h-0.5 bbg-orange-200"></div> {/* 横线，用于分隔 */}
       <button
         className="code-language mr-1 mt-1 text-xs font-mono absolute top-0 right-0 px-2 leading-6 border btn-text rounded-lg "
         onClick={handleCopyButtonClick}

--- a/web/src/labs/marked/parser/CodeBlock.tsx
+++ b/web/src/labs/marked/parser/CodeBlock.tsx
@@ -34,14 +34,16 @@ const renderer = (rawStr: string) => {
 
   return (
     <pre className="group block-code">
-      <div className="language-info absolute top-0 left-0 px-2 py-1 text-xs font-mono bg-gray-800 text-white rounded-tl-lg rounded-br-lg">
+      <div className="language-info absolute top-0 left-0 px-2 py-1 text-xs font-mono bg-indigo-600 text-white rounded-bl-lg rounded-tr-lg">
         {language}
       </div>
+      <div className="w-full h-0.5 bg-indigo-600 mt-1"></div> {/* 横线，用于分隔 */}
+      <pre className="group block-code mt-2"> {/* 添加 margin-top 使代码块稍微下移 */}
       <button
         className="code-language mr-1 mt-1 text-xs font-mono absolute top-0 right-0 px-2 leading-6 border btn-text rounded-lg "
         onClick={handleCopyButtonClick}
       >
-        copy
+        复制
       </button>
       <code className={`language-${language}`} dangerouslySetInnerHTML={{ __html: highlightedCode }}></code>
     </pre>

--- a/web/src/labs/marked/parser/CodeBlock.tsx
+++ b/web/src/labs/marked/parser/CodeBlock.tsx
@@ -34,6 +34,9 @@ const renderer = (rawStr: string) => {
 
   return (
     <pre className="group block-code">
+      <div className="language-info absolute top-0 left-0 px-2 py-1 text-xs font-mono bg-gray-800 text-white rounded-tl-lg rounded-br-lg">
+        {language}
+      </div>
       <button
         className="code-language mr-1 mt-1 text-xs font-mono absolute top-0 right-0 px-2 leading-6 border btn-text rounded-lg "
         onClick={handleCopyButtonClick}

--- a/web/src/labs/marked/parser/CodeBlock.tsx
+++ b/web/src/labs/marked/parser/CodeBlock.tsx
@@ -33,12 +33,11 @@ const renderer = (rawStr: string) => {
   };
 
   return (
-    <pre className="group block-code">
+    <pre className="group block-code mt-2">
       <div className="language-info absolute top-0 left-0 px-2 py-1 text-xs font-mono bg-indigo-600 text-white rounded-bl-lg rounded-tr-lg">
         {language}
       </div>
-      <div className="w-full h-0.5 bg-indigo-600 mt-1"></div> {/* 横线，用于分隔 */}
-      <pre className="group block-code mt-2"> {/* 添加 margin-top 使代码块稍微下移 */}
+      <div className="w-full h-0.5 bg-indigo-600"></div> {/* 横线，用于分隔 */}
       <button
         className="code-language mr-1 mt-1 text-xs font-mono absolute top-0 right-0 px-2 leading-6 border btn-text rounded-lg "
         onClick={handleCopyButtonClick}

--- a/web/src/labs/marked/parser/DoneList.tsx
+++ b/web/src/labs/marked/parser/DoneList.tsx
@@ -17,7 +17,7 @@ const renderer = (rawStr: string) => {
       <span className="todo-block done" data-value="DONE">
         ✓
       </span>
-      <span className="task_checked">{parsedContent}</span>
+      <span className="task_checked strikethrough">{parsedContent}</span>
     </p>
   );
 };


### PR DESCRIPTION
## 输入的代码
![输入的代码](https://github.com/user-attachments/assets/eff5156f-d94d-4ef5-a984-c2caacac3c81)
在原来的版本中，是不会显示语言类型的
## 显示效果
![显示效果](https://github.com/user-attachments/assets/b59a3530-7b5a-4080-8595-4bc91eafeb8e)
新增了显示语言类型的显示
全部的代码就都依靠ai完成，写的不对的请指正
